### PR TITLE
Update summary_subgroup.R

### DIFF
--- a/R/summary_subgroup.R
+++ b/R/summary_subgroup.R
@@ -26,18 +26,15 @@ summary.subgroup_fitted <- function(object, digits = max(getOption('digits')-3, 
 
         ## if variables are selected print out how many are selected
         ## and their coefficient estimates
-        if (length(sel.idx) > 0)
-        {
-            sel.varnames <- vnames[sel.idx]
-            cat(length(sel.idx), "variables selected by the lasso (cross validation criterion).\n\n")
-            coefmat <- matrix(est.coef[sel.idx], ncol = 1)
-            rownames(coefmat) <- sel.varnames
-            colnames(coefmat) <- "Estimate"
-            print.default(round(coefmat, digits), quote = FALSE, right = TRUE, na.print = "NA", ...)
-        } else
-        {
-            cat("No variables selected by the lasso with cross validation. \n\n")
-        }
+        sel.varnames <- vnames[sel.idx]
+        cat(length(sel.idx)-2, 
+            "out of",
+            length(est.coef)-2,
+            "variables selected by the lasso (cross validation criterion).\n\n")
+        coefmat <- matrix(est.coef[sel.idx], ncol = 1)
+        rownames(coefmat) <- sel.varnames
+        colnames(coefmat) <- "Estimate"
+        print.default(round(coefmat, digits), quote = FALSE, right = TRUE, na.print = "NA", ...)
     } else
     {
         return(summary(object$model))


### PR DESCRIPTION
Made the following changes:
1) Added the denominator to the number of variables selected in the description (e.g. m out of n variables selected by the lasso).
2) Subtracted 2 to remove the treatment effect and intercept from the calculations in 1), as one might argue that the treatment effect is not "selected" by the lasso. Even though Intercept = F in the models, it is still present in est.coef.
3) Removed "if length(sel.idx) > 0" condition. Since Trt is always estimated, this condition appeared to be tautologically true. If treatment is the only variable present, it will just say that 0 variables out of X were selected but still should proceed to printing the treatment effect anyway.
4) This may need to be better generalized if the user intends to specify penalty.factor in the call to fit.subgroup().