### PR TITLE
Making Coefficients Available to fit.subgroup()

### DIFF
--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -343,6 +343,7 @@ fit.subgroup <- function(x,
     fitted.model$larger.outcome.better <- larger.outcome.better
     fitted.model$var.names             <- vnames
     fitted.model$benefit.scores        <- fitted.model$predict(x)
+    fitted.model$coefficients          <- fitted.model$coefs
 
     # calculate sizes of subgroups and the
     # subgroup treatment effects based on the


### PR DESCRIPTION
I'm hoping this functionality will make coefficients available to the "fit.subgroup" class. It should be dynamic enough to handle all available fitting methods, with no coefficients being returned for GBM models, since the notion of "coefficients" in that environment is not as intuitive as when using GAM or LASSO.

Also, I aimed to take advantage of the common prediction function definitions in order to avoid repeated, identical definitions within each fitting function. Hopefully this cuts down on the length of the fit_losses file a bit.

If there ever was a need to extract more information from the models in the future, this same technique could be extended (common definitions by fit type can be defined at the top).