### PR TITLE
Incorporating "matching.id" - Phase I

### DIFF
--- a/R/fit_losses.R
+++ b/R/fit_losses.R
@@ -187,7 +187,7 @@ fit_sq_loss_lasso <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
         df.folds <- data.frame(matching.id = sample(levels(matching.id)),
                                fold.id = 1:length(levels(matching.id)) %% nfolds) 
         # Obtain vector of fold IDs with respect to the data
-        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
+        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]}) +1
     } else {
         if ("foldid" %in% dot.names) {
             foldid <- list.dots$foldid
@@ -253,7 +253,7 @@ fit_cox_loss_lasso <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
         df.folds <- data.frame(matching.id = sample(levels(matching.id)),
                                fold.id = 1:length(levels(matching.id)) %% nfolds) 
         # Obtain vector of fold IDs with respect to the data
-        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
+        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]}) +1
     } else {
         if ("foldid" %in% dot.names) {
             foldid <- list.dots$foldid
@@ -352,7 +352,7 @@ fit_sq_loss_lasso_gam <- function(x, y, trt, n.trts, wts, family, matching.id, .
         df.folds <- data.frame(matching.id = sample(levels(matching.id)),
                                fold.id = 1:length(levels(matching.id)) %% nfolds) 
         # Obtain vector of fold IDs with respect to the data
-        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
+        foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]}) +1
     } else {
         if ("foldid" %in% dot.names) {
             foldid <- list.dots$foldid

--- a/R/fit_losses.R
+++ b/R/fit_losses.R
@@ -189,9 +189,11 @@ fit_sq_loss_lasso <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
         # Obtain vector of fold IDs with respect to the data
         foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
     } else {
-        foldid <- ifelse("foldid" %in% dot.names,
-                         list.dots$foldid,
-                         sample(rep(seq(nfolds), length = nrow(x))))
+        if ("foldid" %in% dot.names) {
+            foldid <- list.dots$foldid
+        } else {
+            foldid <- sample(rep(seq(nfolds), length = nrow(x)))
+        }
     }
     list.dots$foldid <- foldid
 
@@ -253,9 +255,11 @@ fit_cox_loss_lasso <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
         # Obtain vector of fold IDs with respect to the data
         foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
     } else {
-        foldid <- ifelse("foldid" %in% dot.names,
-                         list.dots$foldid,
-                         sample(rep(seq(nfolds), length = nrow(x))))
+        if ("foldid" %in% dot.names) {
+            foldid <- list.dots$foldid
+        } else {
+            foldid <- sample(rep(seq(nfolds), length = nrow(x)))
+        }
     }
     list.dots$foldid <- foldid
 
@@ -350,9 +354,12 @@ fit_sq_loss_lasso_gam <- function(x, y, trt, n.trts, wts, family, matching.id, .
         # Obtain vector of fold IDs with respect to the data
         foldid <- sapply(matching.id, function(z) {df.folds[which(z == df.folds$matching.id),"fold.id"]} )
     } else {
-        foldid <- ifelse("foldid" %in% dot.names,
-                         list.dots$foldid,
-                         sample(rep(seq(nfolds), length = nrow(x))))
+        if ("foldid" %in% dot.names) {
+            foldid <- list.dots$foldid
+        } else 
+        {
+            foldid <- sample(rep(seq(nfolds), length = nrow(x)))
+        }
     }
     list.dots$foldid <- foldid
     

--- a/R/fit_losses.R
+++ b/R/fit_losses.R
@@ -307,29 +307,7 @@ fit_sq_loss_lasso_gam <- function(x, y, trt, n.trts, wts, family, matching.id, .
   {
     list.dots$penalty.factor <- c(0, rep(1, ncol(x) - 1))
   }
-
-  glmnet.argnames <- union(names(formals(cv.glmnet)), names(formals(glmnet)))
-  gam.argnames    <- names(formals(gam))
-
-
-
-  # since 'method' is an argument of 'fit.subgrp',
-  # let the user change the gam 'method' arg by supplying
-  # 'method.gam' arg instead of 'method'
-  dot.names[dot.names == "method.gam"] <- "method"
-  names(list.dots)[names(list.dots) == "method.gam"] <- "method"
-
-
-
-
-  # find the arguments relevant for each
-  # possible ...-supplied function
-  dots.idx.glmnet <- match(glmnet.argnames, dot.names)
-  dots.idx.gam    <- match(gam.argnames, dot.names)
-
-  dots.idx.glmnet <- dots.idx.glmnet[!is.na(dots.idx.glmnet)]
-  dots.idx.gam    <- dots.idx.gam[!is.na(dots.idx.gam)]
-
+    
     ## Establish nfolds for cv.glmnet()
     if ("nfolds" %in% dot.names) {
         nfolds <- list.dots$nfolds
@@ -362,21 +340,29 @@ fit_sq_loss_lasso_gam <- function(x, y, trt, n.trts, wts, family, matching.id, .
         }
     }
     list.dots$foldid <- foldid
+
+  glmnet.argnames <- union(names(formals(cv.glmnet)), names(formals(glmnet)))
+  gam.argnames    <- names(formals(gam))
+
+  # since 'method' is an argument of 'fit.subgrp',
+  # let the user change the gam 'method' arg by supplying
+  # 'method.gam' arg instead of 'method'
+  dot.names[dot.names == "method.gam"] <- "method"
+  names(list.dots)[names(list.dots) == "method.gam"] <- "method"
+     
+  # find the arguments relevant for each
+  # possible ...-supplied function
+  dots.idx.glmnet <- match(glmnet.argnames, dot.names)
+  dots.idx.gam    <- match(gam.argnames, dot.names)
+
+  dots.idx.glmnet <- dots.idx.glmnet[!is.na(dots.idx.glmnet)]
+  dots.idx.gam    <- dots.idx.gam[!is.na(dots.idx.gam)]
     
   # fit a model with a lasso
   # penalty and desired loss:
-  # only add in dots calls if they exist
-  if (length(dots.idx.glmnet) > 0)
-  {
-    sel.model <- do.call(cv.glmnet, c(list(x = x, y = y, weights = wts, family = family,
-                                           nfolds = nfolds, foldid = foldid,
-                                           intercept = FALSE), list.dots[dots.idx.glmnet]))
-  } else
-  {
-    sel.model <- do.call(cv.glmnet, list(x = x, y = y, weights = wts, family = family,
-                                         nfolds = nfolds, foldid = foldid,
-                                         intercept = FALSE))
-  }
+  sel.model <- do.call(cv.glmnet, c(list(x = x, y = y, weights = wts, family = family,
+                                         intercept = FALSE), list.dots[dots.idx.glmnet]))
+
 
   vnames <- colnames(x)
 

--- a/R/fit_losses.R
+++ b/R/fit_losses.R
@@ -591,6 +591,10 @@ fit_sq_loss_gbm <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
   {
     list.dots$cv.folds <- 5L
   }
+    
+  if (!is.null(matching.id)) {
+      warning("Matched groups are not guaranteed to remain matched in the cross-validation procedure using GBM models.")
+  }
 
 
   df <- data.frame(y = y, x)
@@ -649,7 +653,10 @@ fit_abs_loss_gbm <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
   {
     list.dots$cv.folds <- 5L
   }
-
+    
+  if (!is.null(matching.id)) {
+      warning("Matched groups are not guaranteed to remain matched in the cross-validation procedure using GBM models.")
+  }
 
   df <- data.frame(y = y, x)
 
@@ -708,6 +715,9 @@ fit_logistic_loss_gbm <- function(x, y, trt, n.trts, wts, family, matching.id, .
     list.dots$cv.folds <- 5L
   }
 
+  if (!is.null(matching.id)) {
+      warning("Matched groups are not guaranteed to remain matched in the cross-validation procedure using GBM models.")
+  }
 
   df <- data.frame(y = y, x)
 
@@ -823,6 +833,10 @@ fit_cox_loss_gbm <- function(x, y, trt, n.trts, wts, family, matching.id, ...)
   } else
   {
     list.dots$cv.folds <- 5L
+  }
+    
+  if (!is.null(matching.id)) {
+      warning("Matched groups are not guaranteed to remain matched in the cross-validation procedure using GBM models.")
   }
 
   surv.vnames <- colnames(y)

--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -406,9 +406,11 @@ fit.subgroup <- function(x,
     }
   
     # compute propensity scores
-    pi.x <- ifelse(is.null(matching.id),
-                   propensity.func(x = x, trt = trt),
-                   propensity.func(x = x, trt = trt, matching.id = matching.id))
+    if (is.null(matching.id)) {
+      pi.x <- propensity.func(x = x, trt = trt)
+    } else {
+      pi.x <- propensity.func(x = x, trt = trt, matching.id = matching.id)
+    }
 
     # make sure the resulting propensity scores are in the
     # acceptable range (ie 0-1)

--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -388,17 +388,23 @@ fit.subgroup <- function(x,
 
     # check to make sure arguments of propensity.func are correct
     propfunc.names <- sort(names(formals(propensity.func)))
-    if (length(propfunc.names) %in% 2:3)
+    if (length(propfunc.names) == 3)
     {
-        if (any(propfunc.names != c("matching.id", "trt", "x")))
-        {
-            stop("arguments of propensity.func() should be 'trt','x', and (optionally) 'matching.id'")
-        }
+      if (any(propfunc.names != c("matching.id", "trt", "x")))
+      {
+        stop("arguments of propensity.func() should be 'trt','x', and (optionally) 'matching.id'")
+      }
+    } else if (length(propfunc.names) == 2) 
+    {
+      if (any(propfunc.names != c("trt", "x")))
+      {
+        stop("arguments of propensity.func() should be 'trt','x', and (optionally) 'matching.id'")
+      }
     } else
     {
-        stop("propensity.func() should only have two or three arguments: 'trt' and 'x', or: 'trt', 'x', and 'matching.id'")
+      stop("propensity.func() should only have two or three arguments: 'trt' and 'x', or: 'trt', 'x', and 'matching.id'")
     }
-
+  
     # compute propensity scores
     pi.x <- drop(do.call(propensity.func, ifelse(is.null(matching.id),
                                              list(x = x, trt = trt),

--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -165,6 +165,7 @@ fit.subgroup <- function(x,
                                         "logistic_loss_gbm",
                                         "cox_loss_gbm"),
                          method     = c("weighting", "a_learning"),
+                         matching.id = NULL,
                          augment.func = NULL,
                          cutpoint   = 0,
                          larger.outcome.better = TRUE,
@@ -283,34 +284,66 @@ fit.subgroup <- function(x,
         stop("gbm and gam based losses not supported for multiple treatments (number of total treatments > 2)")
     }
 
+    # Check matching.id validity and convert it to a factor, if supplied
+    if (!is.null(matching.id)) {
+        matching.id <- tryCatch(expr=as.factor(matching.id), error = function(e) {stop("matching.id must be a factor or capable of being coerced to a factor.")})
+        if (length(levels(matching.id)) < 2) {stop("matching.id must have at least 2 levels")}
+    }
+  
     # defaults to constant propensity score within trt levels
     # the user will almost certainly want to change this
     if (is.null(propensity.func))
     {
+      if (is.null(matching.id)) 
+      { # No propensity score supplied and no matching.id supplied
         if (n.trts == 2)
         {
-            mean.trt <- mean(trt == unique.trts[2L])
-            propensity.func <- function(trt, x) rep(mean.trt, length(trt))
-        } else
+        mean.trt <- mean(trt == unique.trts[2L])
+        propensity.func <- function(trt, x) rep(mean.trt, length(trt))
+          } else
         {
-            mean.trt <- numeric(n.trts)
+          mean.trt <- numeric(n.trts)
+          for (t in 1:n.trts)
+          {
+            mean.trt[t] <- mean(trt == unique.trts[t])
+          }
+          propensity.func <- function(trt, x)
+          {
+            pi.x <- numeric(length(trt))
             for (t in 1:n.trts)
             {
-                mean.trt[t] <- mean(trt == unique.trts[t])
+              which.t       <- trt == unique.trts[t]
+              pi.x[which.t] <- mean(which.t)
             }
-            propensity.func <- function(trt, x)
-            {
-                pi.x <- numeric(length(trt))
-                for (t in 1:n.trts)
-                {
-                    which.t       <- trt == unique.trts[t]
-                    pi.x[which.t] <- mean(which.t)
-                }
-
-                pi.x
-            }
+            pi.x
+          }
         }
+      } else
+      { # No propensity score supplied but matching.id supplied
+        if (n.trts == 2)
+        {
+          mean.trt <- mean(trt == unique.trts[2L])
+          propensity.func <- function(trt, x, matching.id) rep(mean.trt, length(trt))
+          } else
+        {
+          mean.trt <- numeric(n.trts)
+          for (t in 1:n.trts)
+          {
+            mean.trt[t] <- mean(trt == unique.trts[t])
+          }
+          propensity.func <- function(trt, x, matching.id)
+          {
+            pi.x <- numeric(length(trt))
+            for (t in 1:n.trts)
+            {
+              which.t       <- trt == unique.trts[t]
+              pi.x[which.t] <- mean(which.t)
+            }
+            pi.x
+        }
+      }
     }
+  }
 
 
     # check to make sure arguments of augment.func are correct
@@ -355,19 +388,22 @@ fit.subgroup <- function(x,
 
     # check to make sure arguments of propensity.func are correct
     propfunc.names <- sort(names(formals(propensity.func)))
-    if (length(propfunc.names) == 2)
+    if (length(propfunc.names) %in% 2:3)
     {
-        if (any(propfunc.names != c("trt", "x")))
+        if (any(propfunc.names != c("matching.id", "trt", "x")))
         {
-            stop("arguments of propensity.func() should be 'x' and 'trt'")
+            stop("arguments of propensity.func() should be 'trt','x', and (optionally) 'matching.id'")
         }
     } else
     {
-        stop("propensity.func() should only have two arguments: 'trt' and 'x'")
+        stop("propensity.func() should only have two or three arguments: 'trt' and 'x', or: 'trt', 'x', and 'matching.id'")
     }
 
     # compute propensity scores
-    pi.x   <- drop(propensity.func(x = x, trt = trt))
+    pi.x <- drop(do.call(propensity.func, ifelse(is.null(matching.id),
+                                             list(x = x, trt = trt),
+                                             list(x = x, trt = trt, matching.id = matching.id)))
+             )
 
     # make sure the resulting propensity scores are in the
     # acceptable range (ie 0-1)
@@ -449,7 +485,8 @@ fit.subgroup <- function(x,
     # identify correct fitting function and call it
     fit_fun      <- paste0("fit_", loss)
     fitted.model <- do.call(fit_fun, list(x = x.tilde, trt = trt, n.trts = n.trts,
-                                          y = y.adj, wts = wts, family = family, ...))
+                                          y = y.adj, wts = wts, family = family,
+                                          matching.id = matching.id, ...))
 
 
     # save extra results

--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -406,10 +406,9 @@ fit.subgroup <- function(x,
     }
   
     # compute propensity scores
-    pi.x <- drop(do.call(propensity.func, ifelse(is.null(matching.id),
-                                             list(x = x, trt = trt),
-                                             list(x = x, trt = trt, matching.id = matching.id)))
-             )
+    pi.x <- ifelse(is.null(matching.id),
+                   propensity.func(x = x, trt = trt),
+                   propensity.func(x = x, trt = trt, matching.id = matching.id))
 
     # make sure the resulting propensity scores are in the
     # acceptable range (ie 0-1)

--- a/R/fit_subgroup.R
+++ b/R/fit_subgroup.R
@@ -407,9 +407,9 @@ fit.subgroup <- function(x,
   
     # compute propensity scores
     if (is.null(matching.id)) {
-      pi.x <- propensity.func(x = x, trt = trt)
+      pi.x <- drop(propensity.func(x = x, trt = trt))
     } else {
-      pi.x <- propensity.func(x = x, trt = trt, matching.id = matching.id)
+      pi.x <- drop(propensity.func(x = x, trt = trt, matching.id = matching.id))
     }
 
     # make sure the resulting propensity scores are in the

--- a/R/validate_subgroup.R
+++ b/R/validate_subgroup.R
@@ -183,6 +183,7 @@ validate.subgroup <- function(model,
                 n.levels    <- length(levels(matching.id))
                 samp.levels <- sample.int(n.levels, n.levels * train.fraction, replace = FALSE)
                 samp.idx    <- which(matching.id %in% levels(matching.id)[samp.levels])
+                model$call$matching.id <- matching.id[samp.idx]
               }
                 model$call$x    <- x[samp.idx,]
                 model$call$trt  <- trt[samp.idx]
@@ -326,6 +327,7 @@ validate.subgroup <- function(model,
                 n.levels    <- length(levels(matching.id))
                 samp.levels <- sample.int(n.levels, n.levels * train.fraction, replace = FALSE)
                 samp.idx    <- which(matching.id %in% levels(matching.id)[samp.levels])
+                model$call$matching.id <- matching.id[samp.idx]
               }
                 model$call$x    <- x[samp.idx,]
                 model$call$trt  <- trt[samp.idx]

--- a/R/validate_subgroup.R
+++ b/R/validate_subgroup.R
@@ -135,9 +135,10 @@ validate.subgroup <- function(model,
 
     # save data objects because they
     # will be written over by resampled versions later
-    x   <- model$call$x
-    trt <- model$call$trt
-    y   <- model$call$y
+    x           <- model$call$x
+    trt         <- model$call$trt
+    y           <- model$call$y
+    matching.id <- model$call$matching.id
 
     ## override any internal parallelization
     ## if there is a conflict of parallelization
@@ -174,8 +175,15 @@ validate.subgroup <- function(model,
             if (method == "training_test_replication")
             {
                 # randomly split/partition data into training and testing sets
+              if (is.null(matching.id)) {
                 train.samp.size <- floor(n.obs * train.fraction)
                 samp.idx        <- sample.int(n.obs, train.samp.size, replace = FALSE)
+              } else {
+                # Draw at the cluster level (train.fraction interpreted as fraction of clusters)
+                n.levels    <- length(levels(matching.id))
+                samp.levels <- sample.int(n.levels, n.levels * train.fraction, replace = FALSE)
+                samp.idx    <- which(matching.id %in% levels(matching.id)[samp.levels])
+              }
                 model$call$x    <- x[samp.idx,]
                 model$call$trt  <- trt[samp.idx]
 
@@ -215,7 +223,17 @@ validate.subgroup <- function(model,
             {   # bootstrap bias correction
 
                 # take a bootstrap sample with replacement
+              if (is.null(matching.id)) {
                 samp.idx <- sample.int(n.obs, n.obs, replace = TRUE)
+              } else {
+                # Draw at the cluster level
+                samp.levels <- sample(levels(matching.id), replace = TRUE)
+                samp.lookup <- lapply(samp.levels, function(z) {which(matching.id == z)})
+                samp.idx    <- unlist(samp.lookup)
+                # Remap matching IDs so that each cluster draw is assigned a unique matching ID
+                samp.lengths           <- lapply(samp.lookup,length)
+                model$call$matching.id <- unlist(lapply(1:length(samp.lengths),function(z){rep(z,samp.lengths[[z]])}))
+              }
                 model$call$x   <- x[samp.idx,]
 
                 if (is.matrix(y))
@@ -254,7 +272,17 @@ validate.subgroup <- function(model,
 
                 # bootstrap is not available because it
                 # results in overly optimistic results
-                samp.idx       <- sample.int(n.obs, n.obs, replace = TRUE)
+              if (is.null(matching.id)) {
+                samp.idx <- sample.int(n.obs, n.obs, replace = TRUE)
+              } else {
+                # Draw at the cluster level
+                samp.levels <- sample(levels(matching.id), replace = TRUE)
+                samp.lookup <- lapply(samp.levels, function(z) {which(matching.id == z)})
+                samp.idx    <- unlist(samp.lookup)
+                # Remap matching IDs so that each cluster draw is assigned a unique matching ID
+                samp.lengths           <- lapply(samp.lookup,length)
+                model$call$matching.id <- unlist(lapply(1:length(samp.lengths),function(z){rep(z,samp.lengths[[z]])}))
+              }
                 model$call$x   <- x[samp.idx,]
                 model$call$y   <- y[samp.idx]
                 model$call$trt <- trt[samp.idx]
@@ -290,8 +318,15 @@ validate.subgroup <- function(model,
             if (method == "training_test_replication")
             {
                 # randomly split/partition data into training and testing sets
+              if (is.null(matching.id)) {
                 train.samp.size <- floor(n.obs * train.fraction)
                 samp.idx        <- sample.int(n.obs, train.samp.size, replace = FALSE)
+              } else {
+                # Draw at the cluster level (train.fraction interpreted as fraction of clusters)
+                n.levels    <- length(levels(matching.id))
+                samp.levels <- sample.int(n.levels, n.levels * train.fraction, replace = FALSE)
+                samp.idx    <- which(matching.id %in% levels(matching.id)[samp.levels])
+              }
                 model$call$x    <- x[samp.idx,]
                 model$call$trt  <- trt[samp.idx]
 
@@ -331,7 +366,17 @@ validate.subgroup <- function(model,
             {   # bootstrap bias correction
 
                 # take a bootstrap sample with replacement
+              if (is.null(matching.id)) {
                 samp.idx <- sample.int(n.obs, n.obs, replace = TRUE)
+              } else {
+                # Draw at the cluster level
+                samp.levels <- sample(levels(matching.id), replace = TRUE)
+                samp.lookup <- lapply(samp.levels, function(z) {which(matching.id == z)})
+                samp.idx    <- unlist(samp.lookup)
+                # Remap matching IDs so that each cluster draw is assigned a unique matching ID
+                samp.lengths           <- lapply(samp.lookup,length)
+                model$call$matching.id <- unlist(lapply(1:length(samp.lengths),function(z){rep(z,samp.lengths[[z]])}))
+              }
                 model$call$x   <- x[samp.idx,]
 
                 if (is.matrix(y))
@@ -370,7 +415,17 @@ validate.subgroup <- function(model,
 
                 # bootstrap is not available because it
                 # results in overly optimistic results
-                samp.idx       <- sample.int(n.obs, n.obs, replace = TRUE)
+                if (is.null(matching.id)) {
+                  samp.idx <- sample.int(n.obs, n.obs, replace = TRUE)
+                } else {
+                  # Draw at the cluster level
+                  samp.levels <- sample(levels(matching.id), replace = TRUE)
+                  samp.lookup <- lapply(samp.levels, function(z) {which(matching.id == z)})
+                  samp.idx    <- unlist(samp.lookup)
+                  # Remap matching IDs so that each cluster draw is assigned a unique matching ID
+                  samp.lengths           <- lapply(samp.lookup,length)
+                  model$call$matching.id <- unlist(lapply(1:length(samp.lengths),function(z){rep(z,samp.lengths[[z]])}))
+                }
                 model$call$x   <- x[samp.idx,]
                 model$call$y   <- y[samp.idx]
                 model$call$trt <- trt[samp.idx]


### PR DESCRIPTION
- Took on a "do no harm" approach to incorporating a `matching.id` variable, so that if `matching.id` is unspecified (`NULL`), then all behavior *should* be exactly as before.

- The update should achieve incorporating the matching ID in the folds of all `cv.glmnet` calls (i.e. matched groups are always members of the same fold).

- This also happens in the bootstrapped sampling routines, where it's slightly more complicated: If a matching ID is supplied, then `train.fraction` is interpreted as the fraction of clusters instead of observations. Additionally, when drawn, clusters are assigned a new `matching.id` to reflect their draws as "new" random samples in the call to be passed back to `fit.subgroup`.

- There are two unfinished aspects to this work:

1) Currently, setting `propensity.func()` with or without `matching.id` has no practical consequence. However, the conditional logic is in place so that different behavior can be incorporated when a user specifies any combination of `matching.id` (Y/N) x `propensity.func` (Y/N) x `n.trt` (==2 or more). Before deciding on the logic for every possibility, I thought it would be best to first reach this checkpoint.

2) It's unclear how to connect the `matching.id` to the `gbm` function in the same way that it was done for `cv.glmnet` to assign each cluster to its own fold. While this function can take a  `cv.folds` argument, it doesn't seem to allow for direct interface with the folds themselves. This is in contrast to `cv.glmnet`, which does allow for such specification via `foldid`. If this can't be resolved, it may be worth warning the user that the cross-validation technique in `gbm.perf` constructs folds without regard to the matched data.